### PR TITLE
Fix: On boarding | User is unable to move when emoting too fast

### DIFF
--- a/src/quest/questEmote.ts
+++ b/src/quest/questEmote.ts
@@ -235,6 +235,8 @@ export class QuestEmote {
     AvatarEmoteCommand.onChange(engine.PlayerEntity, (emote) => {
       if (!emote) return
       if (this.currentEmote === emote.emoteUrn) return
+      // Ignore emotes if quest is completed (emoteMoves set to -1)
+      if (this.emoteMoves < 0) return
 
       cameraManager.lockPlayer()
 
@@ -418,6 +420,9 @@ export class QuestEmote {
     await wait_ms(3000)
     Animator.stopAllAnimations(this.bezier.entity)
     Animator.getClip(this.bezier.entity, 'Talk').playing = true
+    
+    // Ensure player is unlocked after quest completion
+    cameraManager.unlockPlayer()
   }
   spawnParticles() {
     const particle = engine.addEntity()
@@ -617,6 +622,10 @@ export class QuestEmote {
     // this.dialogQuestFinished()
   }
   async dialogQuestFinished() {
+    // Clean up emote listener to prevent player from getting stuck in later quests
+    // Set flag to ignore further emote events after quest completion
+    this.emoteMoves = -1
+    
     this.bubbleTalk.openBubble(ZONE_1_EMOTE_4, true)
     cameraManager.unlockPlayer()
     this.gameController.uiController.widgetTasks.showTick(false, 0)

--- a/src/quest/questStartIsland.ts
+++ b/src/quest/questStartIsland.ts
@@ -554,7 +554,39 @@ export class SpawnIsland {
       ]
     })
     let tween = 0
+    let tweenSystemActive = true
+    
+    // Add timeout fallback for tween sequence
+    utils.timers.setTimeout(() => {
+      if (tween < 5 && tweenSystemActive) {
+        console.log('Tween sequence incomplete after 10 seconds, forcing completion')
+        tweenSystemActive = false
+        
+        // Force robot to final position and setup interaction
+        this.tobor.activateBillBoard(true)
+        this.targeterCircle.showCircle(true)
+        this.setupDialogAtPilarTargeter()
+        pointerEventsSystem.onPointerDown(
+          {
+            entity: this.tobor.npcChild,
+            opts: {
+              button: InputAction.IA_POINTER,
+              hoverText: 'Talk'
+            }
+          },
+          () => {
+            pointerEventsSystem.removeOnPointerDown(this.tobor.npcChild)
+            console.log('CLICKED')
+            this.toborTalkAfterJumpQuest()
+          }
+        )
+        console.log('tobor on pilar - forced by timeout')
+      }
+    }, 30000)
+    
     engine.addSystem(() => {
+      if (!tweenSystemActive) return
+      
       const tweenCompleted = tweenSystem.tweenCompleted(this.tobor.entity)
       if (tweenCompleted) {
         tween = tween + 1
@@ -565,6 +597,7 @@ export class SpawnIsland {
           this.jumpquest()
         }
         if (tween === 5) {
+          tweenSystemActive = false
           this.tobor.activateBillBoard(true)
           this.targeterCircle.showCircle(true)
           this.setupDialogAtPilarTargeter()


### PR DESCRIPTION
Fix [#4823](https://github.com/decentraland/unity-explorer/issues/4823)

Read this file for the bug analysis
[TUTORIAL_BUGS_ANALYSIS.md](https://github.com/user-attachments/files/21584705/TUTORIAL_BUGS_ANALYSIS.md)

# Test instructions 
1. Download and unzip code of [this repo](https://github.com/decentraland-scenes/dcl_sdk7_onboarding/archive/refs/heads/fix/player-block-when-free-emoting.zip)
2. Open terminal and locate to the root folder (via `cd ROOT_FOLDER_PATH`  command)
3. Then run in the terminal `npm i`
4. Then run in the terminal `npm run start -- --explorer-alpha` (on Windows it may need to be `npm run start ‘--’ --explorer-alpha`)
5. Follow to the original bug ticket and test respective bug - it should not be present
6. All other part of tutorial should be as in the prod 